### PR TITLE
added PHP 7.0-7.4, 8.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ jobs:
       dist: xenial
     - php: 7.1
       dist: xenial
+  allow_failures:
+    - php: 8.0
 
 # Install dependencies before testing
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
 
 # Run coveralls.io code coverage report
 after_script:
-  - vendor/bin/coveralls -v
+  - vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 # .travis.yml
 
 language: php
+dist: bionic
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - 7.4
   - 8.0
+
+jobs:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: xenial
 
 # Install dependencies before testing
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@
 language: php
 dist: bionic
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
@@ -19,6 +17,10 @@ jobs:
     - php: 5.5
       dist: trusty
     - php: 5.6
+      dist: xenial
+    - php: 7.0
+      dist: xenial
+    - php: 7.1
       dist: xenial
 
 # Install dependencies before testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
 
 # Install dependencies before testing
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 8.0
 
 jobs:
+  fast_finish: true
   include:
     - php: 5.3
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
 # Install dependencies before testing
 before_script:
   - composer selfupdate
-  - composer install --dev
+  - composer install
 
 # Use our custom version of phpunit
 script:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require-dev": {
     "monolog/monolog": "~1.0",
     "phpunit/phpunit": "~4.0",
-    "satooshi/php-coveralls": "dev-master"
+    "php-coveralls/php-coveralls": "^1.1|^2.4"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- fixed Travis config for PHP 5.3-5.6
- added PHP 7.0+ to Travis config
- replaced deprecated satooshi/php-coveralls
- fixed deprecation warning for Composer 2